### PR TITLE
Make jwk url and issuer configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /build/
 /*/build/
+/*/out/

--- a/maskinporten-validation-core/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/MaskinportenValidator.kt
+++ b/maskinporten-validation-core/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/MaskinportenValidator.kt
@@ -23,7 +23,7 @@ open class MaskinportenValidator(
         )
         jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
             JWTClaimsSet.Builder()
-                .issuer(maskinportenValidatorConfig.baseURL.toExternalForm().postfix('/'))
+                .issuer(maskinportenValidatorConfig.issuer ?: maskinportenValidatorConfig.baseURL.toExternalForm().postfix('/'))
                 .build(),
             setOf("client_id", "client_amr", CONSUMER_CLAIM, "exp", "iat", "jti")
         )

--- a/maskinporten-validation-core/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorConfig.kt
+++ b/maskinporten-validation-core/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorConfig.kt
@@ -9,11 +9,12 @@ import java.net.URL
 
 data class MaskinportenValidatorConfig(
     val baseURL: URL,
+    val jwkURL: URL? = null,
+    val issuer: String? = null,
     internal val proxy: Proxy? = null
 ) {
-
     var jwkSet: JWKSource<SecurityContext> = RemoteJWKSet(
-        URL(baseURL, "/jwk"),
+        jwkURL ?: URL(baseURL, "/jwk"),
         DefaultResourceRetriever().apply {
             proxy = this@MaskinportenValidatorConfig.proxy
         })

--- a/maskinporten-validation-spring/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorProperties.kt
+++ b/maskinporten-validation-spring/src/main/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorProperties.kt
@@ -11,12 +11,16 @@ import java.net.URL
 @ConfigurationProperties("maskinporten.validation")
 class MaskinportenValidatorProperties(
     private val baseURL: String,
+    private val jwkUrl: String?,
+    private val issuer: String?,
     private var proxy: String? = null
 ) {
 
     fun toConfig() = MaskinportenValidatorConfig(
-        URL(baseURL.postfix('/')),
-        proxy?.run {
+        baseURL = URL(baseURL.postfix('/')),
+        jwkURL = jwkUrl?.let { URL(it) },
+        issuer = issuer,
+        proxy = proxy?.run {
             Proxy(
                 Proxy.Type.HTTP,
                 InetSocketAddress(

--- a/maskinporten-validation-spring/src/test/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorConfigurerTest.kt
+++ b/maskinporten-validation-spring/src/test/kotlin/no/nav/pensjonsamhandling/maskinporten/validation/config/MaskinportenValidatorConfigurerTest.kt
@@ -36,8 +36,8 @@ internal class MaskinportenValidatorConfigurerTest {
 
     companion object {
         private val expectedConfig = MaskinportenValidatorConfig(
-            URL("https://maskinporten.no/"),
-            Proxy(HTTP, InetSocketAddress("localhost", 8080))
+            baseURL = URL("https://maskinporten.no/"),
+            proxy = Proxy(HTTP, InetSocketAddress("localhost", 8080))
         )
     }
 }


### PR DESCRIPTION
Med denne endringen så er det mulig å kalle på TP, samt lage integrasjonstester, med VTP sin Maskinporten mock.

Følgende konfigurasjon kan brukes i `application-local.properties` for å bruke VTP som en mock av Maskinporten lokalt.

```
maskinporten.validation.baseURL=http://localhost:8060/rest/maskinporten
maskinporten.validation.jwkURL=http://localhost:8060/rest/maskinporten/jwk
maskinporten.validation.issuer=vtp-maskinporten-issuer
``` 